### PR TITLE
Propuesta Maxima Verosimilitud

### DIFF
--- a/docs/ModelosARIMA.Rmd
+++ b/docs/ModelosARIMA.Rmd
@@ -719,6 +719,35 @@ Si existen dos raíces iguales, digamos $\lambda_1 = \delta_q$ podemos expresar 
      (1-\delta_1 L) (1-\delta_2 L) \dots (1-\delta_{q-1} L) \varepsilon_t
 \end{align}
 
+##
+
+Ahora, miremos la estimación condicional bajo máxima verosimilitud.
+
+bajo el supuesto de $\varepsilon_t \sim N(0, \sigma^2 I)$ la función de densidad de $\varepsilon_t$ es,
+
+\begin{align}
+    f(\varepsilon_t | \sigma^2_{\varepsilon}, \beta, w^0, \varepsilon^0) &  = 
+    (2\pi)^{-0.5} (\sigma^2_{\varepsilon})^{-0.5} {\rm e}^{-\frac{1}{2\sigma^2_{\varepsilon}}\varepsilon_t^2} \\
+    & = (2\pi)^{-0.5} (\sigma^2_{\varepsilon})^{-0.5} {\rm e}^{-\frac{1}{2\sigma^2_{\varepsilon}}(w_t - \dots -  \phi_p w_{t-p} + \theta_1 \varepsilon_{t-1} + \dots + \theta_q\varepsilon_{t-q})^2} \nonumber
+\end{align}
+
+##
+
+La función de densidad conjunta de $\varepsilon_1,\varepsilon_2,\dots,\varepsilon_T$ sera igual al producto de las funciones de densidad marginales, ya que por hipótesis no tiene auto-correlación, por lo tanto:
+
+\begin{align}
+    f(\varepsilon_t | \sigma^2_{\varepsilon}, \beta, w^0, \varepsilon^0) &  = 
+    (2\pi)^{\frac{-T}{2}} (\sigma^2_{\varepsilon})^{\frac{-T}{2}} {\rm e}^{-\frac{1}{2\sigma^2_{\varepsilon}}\sum \varepsilon_t^2} \\
+    & = (2\pi)^{\frac{-T}{2}} (\sigma^2_{\varepsilon})^{\frac{-T}{2}} {\rm e}^{-\frac{1}{2\sigma^2_{\varepsilon}}\sum (w_t - \dots -  \phi_p w_{t-p} + \theta_1 \varepsilon_{t-1} + \dots + \theta_q\varepsilon_{t-q})^2} \nonumber
+\end{align}
+
+##
+
+<ul>
+<li> La maximización de esta función con respecto a $\beta$ nos da los estimadores máximo verosímiles.</li> 
+<li> Se puede observar que maximizar la función anterior corresponde a minimizar la sumatoria del exponencial, lo cual coincide con  el estimador de MCO.</li>
+</ul>
+
 
 # ARIMA(p,d,q)
 


### PR DESCRIPTION
Ampliando el tema de los criterios de información. Donde su formula es el -log(mv) + penalidad. Es importante de forma superifical por lo menos aclarar que es MV. Diapositivas tomadas del las diapositivas de estimación del curso de series de tiempo. La idea que es este bajo las diapostivias propuestas por Alejadra Arteaga para los criterios de información de Akaike y Schwarz.